### PR TITLE
Make sure the encryption key generator is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /tmp
 
 *_key
+!bin/generate_encryption_key
 vagrant/.vagrant
 vagrant/package.box
 .vagrant

--- a/bin/generate_encryption_key
+++ b/bin/generate_encryption_key
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "securerandom"
+
+puts "Your secure encryption token is:\n"
+puts SecureRandom.hex(16)


### PR DESCRIPTION
We ignored all the `*_key` files. Because of that the `bin/generate_encryption_key` was not added to git.