### PR TITLE
Add configuration option for Appsignal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ For changelog of past releases, please check the release branch.
 ## V1.1 - Unreleased
 
 ### Added
-- Nothing Yet
+- Ability to set Appsignal as your Error catcher
 
 ### Changed
 - Nothing Yet

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,7 +1,6 @@
 default: &defaults
   # Your push api key, it is possible to set this dynamically using ERB:
-  # push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
-  push_api_key: "1e11ef3a-a9bb-4193-a55e-0d5dc539034c"
+  push_api_key: "<%= Settings.intercity.try(:appsignal_push_key) %>"
 
   # Your app's name
   name: "Intercity"

--- a/config/intercity.example.yml
+++ b/config/intercity.example.yml
@@ -10,6 +10,9 @@ production: &base
     ## Allow users to create an account
     signup_enabled: true
     signup_url: "/users/sign_up"
+
+    # If you want to use AppSignal for loging, add your key here:
+    # appsignal_push_key: ""
   chef_repo:
     path: "/path/to/chef_repo"
 development:


### PR DESCRIPTION
Since we want to use Appsignal in all our production instances, it makes sense
to make this configurable. By adding an option to the `config/appsignal.yml`
people can make the descision to ue AppSignal as their error catcher as well. We
can expand on this on the future.

/cc @michiels 